### PR TITLE
Updated dotNetZip library because of potential security vulnerabiliti…

### DIFF
--- a/Frends.Community.Unzip.sln
+++ b/Frends.Community.Unzip.sln
@@ -7,6 +7,12 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Frends.Community.Unzip", "F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Frends.Community.UnzipTests", "Frends.Community.UnzipTests\Frends.Community.UnzipTests.csproj", "{A41706AD-7BBF-44CA-A918-3122A5B4DF6F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5CF3AC74-3E7C-471F-8FAA-DB316264495C}"
+	ProjectSection(SolutionItems) = preProject
+		nuspec\Frends.Community.Unzip.nuspec = nuspec\Frends.Community.Unzip.nuspec
+		README.md = README.md
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Frends.Community.Unzip/Frends.Community.Unzip.csproj
+++ b/Frends.Community.Unzip/Frends.Community.Unzip.csproj
@@ -32,8 +32,8 @@
     <DocumentationFile>bin\Release\Frends.Community.Unzip.xml</DocumentationFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.12.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.12.0\lib\net20\DotNetZip.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
@@ -52,13 +52,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="..\nuspec\Frends.Community.Unzip.nuspec">
-      <SubType>Designer</SubType>
-      <Link>Frends.Community.Unzip.nuspec</Link>
-    </None>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Frends.Community.Unzip/packages.config
+++ b/Frends.Community.Unzip/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.10.1" targetFramework="net452" />
+  <package id="DotNetZip" version="1.12.0" targetFramework="net452" />
 </packages>

--- a/Frends.Community.UnzipTests/Frends.Community.UnzipTests.csproj
+++ b/Frends.Community.UnzipTests/Frends.Community.UnzipTests.csproj
@@ -33,8 +33,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="DotNetZip, Version=1.10.1.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
-      <HintPath>..\packages\DotNetZip.1.10.1\lib\net20\DotNetZip.dll</HintPath>
+    <Reference Include="DotNetZip, Version=1.12.0.0, Culture=neutral, PublicKeyToken=6583c7c814667745, processorArchitecture=MSIL">
+      <HintPath>..\packages\DotNetZip.1.12.0\lib\net20\DotNetZip.dll</HintPath>
     </Reference>
     <Reference Include="nunit.framework, Version=3.9.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\packages\NUnit.3.9.0\lib\net45\nunit.framework.dll</HintPath>

--- a/Frends.Community.UnzipTests/packages.config
+++ b/Frends.Community.UnzipTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="DotNetZip" version="1.10.1" targetFramework="net452" />
+  <package id="DotNetZip" version="1.12.0" targetFramework="net452" />
   <package id="NUnit" version="3.9.0" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.9.0" targetFramework="net452" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -87,3 +87,4 @@ NOTE: Be sure to merge the latest from "upstream" before making a pull request!
 | Version             | Changes                 |
 | ---------------------| ---------------------|
 | 1.0.0 | Initial Frends.Community version of the Unzip-task |
+| 1.1.0 | Updated dotNetZip nuget to 1.20.0, if it would not have 'We found potential security vulnerabilities in your dependencies.' issue |

--- a/nuspec/Frends.Community.Unzip.nuspec
+++ b/nuspec/Frends.Community.Unzip.nuspec
@@ -2,14 +2,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
   <metadata>
     <id>Frends.Community.Unzip</id>
-    <version>1.0.2</version>
+    <version>1.1.0</version>
     <title>Frends Community Unzip</title>
     <authors>HiQ Finland</authors>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>Frends Task for Extracting Zip Archives</description>
     <summary />
     <dependencies>
-      <dependency id="DotNetZip" version="1.10.1" />
+      <dependency id="DotNetZip" version="1.12.0" />
     </dependencies>
     <frameworkAssemblies>
       <frameworkAssembly assemblyName="Microsoft.CSharp" />


### PR DESCRIPTION
…es in older version.

Moved nuspec to Solution Items, updated version to 1.1.0 and added change info to README.md